### PR TITLE
feat: add CLI entrypoint and TypeScript setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS
+
+## Overview
+This repository hosts a single-player, terminal-based storytelling engine built on the RanvierMUD core.
+
+## Code Style
+- Write new code in TypeScript under `src/`.
+- Prefer async/await and modern ES2020 features.
+- Avoid adding unnecessary dependencies.
+
+## Testing
+- Run `npm test` and make a best effort to ensure it passes (currently there are no tests and the command will report a missing script).
+- Run a basic smoke check with `npm start` when modifying the CLI.
+
+## Commands
+- `npm start` launches the text-only game loop via `ts-node`.
+- Networking features are disabled; the engine is single-player and terminal-only.
+
+## Notes
+- Use the filesystem for persistence; no database or network server should be introduced.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "start": "node ./ranvier -v",
+    "start": "ts-node src/main.ts",
+    "server": "node ./ranvier -v",
     "init": "node ./util/init-bundles.js",
     "update-bundle-remote": "node ./util/update-bundle-url.js",
     "remove-bundle": "node ./util/remove-bundle.js",
@@ -28,6 +29,8 @@
     "winston": "^2.4.4"
   },
   "devDependencies": {
-    "git-url-parse": "^11.1.2"
+    "git-url-parse": "^11.1.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
   }
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,78 @@
+import path from 'path';
+import fs from 'fs';
+
+const Ranvier: any = require('ranvier');
+
+export async function initGameState() {
+  const Logger = Ranvier.Logger;
+  const Config = Ranvier.Config;
+  const root = path.resolve(__dirname, '..');
+
+  Ranvier.Data.setDataPath(path.join(root, 'data'));
+  const confJs = path.join(root, 'ranvier.conf.js');
+  const confJson = path.join(root, 'ranvier.json');
+  if (fs.existsSync(confJs)) {
+    Config.load(require(confJs));
+  } else if (fs.existsSync(confJson)) {
+    Config.load(require(confJson));
+  } else {
+    throw new Error('No ranvier.json or ranvier.conf.js found');
+  }
+
+  const GameState: any = {
+    AccountManager: new Ranvier.AccountManager(),
+    AreaBehaviorManager: new Ranvier.BehaviorManager(),
+    AreaFactory: new Ranvier.AreaFactory(),
+    AreaManager: new Ranvier.AreaManager(),
+    AttributeFactory: new Ranvier.AttributeFactory(),
+    ChannelManager: new Ranvier.ChannelManager(),
+    CommandManager: new Ranvier.CommandManager(),
+    Config,
+    EffectFactory: new Ranvier.EffectFactory(),
+    HelpManager: new Ranvier.HelpManager(),
+    InputEventManager: new Ranvier.EventManager(),
+    ItemBehaviorManager: new Ranvier.BehaviorManager(),
+    ItemFactory: new Ranvier.ItemFactory(),
+    ItemManager: new Ranvier.ItemManager(),
+    MobBehaviorManager: new Ranvier.BehaviorManager(),
+    MobFactory: new Ranvier.MobFactory(),
+    MobManager: new Ranvier.MobManager(),
+    PartyManager: new Ranvier.PartyManager(),
+    PlayerManager: new Ranvier.PlayerManager(),
+    QuestFactory: new Ranvier.QuestFactory(),
+    QuestGoalManager: new Ranvier.QuestGoalManager(),
+    QuestRewardManager: new Ranvier.QuestRewardManager(),
+    RoomBehaviorManager: new Ranvier.BehaviorManager(),
+    RoomFactory: new Ranvier.RoomFactory(),
+    RoomManager: new Ranvier.RoomManager(),
+    SkillManager: new Ranvier.SkillManager(),
+    SpellManager: new Ranvier.SkillManager(),
+    ServerEventManager: new Ranvier.EventManager(),
+    GameServer: new Ranvier.GameServer(),
+    DataLoader: Ranvier.Data,
+    EntityLoaderRegistry: new Ranvier.EntityLoaderRegistry(),
+    DataSourceRegistry: new Ranvier.DataSourceRegistry(),
+  };
+
+  GameState.DataSourceRegistry.load(require, root, Config.get('dataSources'));
+  GameState.EntityLoaderRegistry.load(GameState.DataSourceRegistry, Config.get('entityLoaders'));
+  GameState.AccountManager.setLoader(GameState.EntityLoaderRegistry.get('accounts'));
+  GameState.PlayerManager.setLoader(GameState.EntityLoaderRegistry.get('players'));
+
+  const BundleManager = new Ranvier.BundleManager(path.join(root, 'bundles'), GameState);
+  GameState.BundleManager = BundleManager;
+  await BundleManager.loadBundles();
+  GameState.ServerEventManager.attach(GameState.GameServer);
+
+  setInterval(() => {
+    GameState.AreaManager.tickAll(GameState);
+    GameState.ItemManager.tickAll();
+  }, Config.get('entityTickFrequency', 100));
+
+  setInterval(() => {
+    GameState.PlayerManager.emit('updateTick');
+  }, Config.get('playerTickFrequency', 100));
+
+  Logger.setLevel(process.env.LOG_LEVEL || Config.get('logLevel') || 'debug');
+  return GameState;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,47 @@
+import readline from 'readline';
+import { initGameState } from './init';
+
+async function main() {
+  const state = await initGameState();
+  const account = await state.AccountManager.loadAccount('Admin');
+  const player = await state.PlayerManager.loadPlayer(state, account, 'Admin');
+
+  player.socket = {
+    writable: true,
+    _prompted: false,
+    write: (data: string) => process.stdout.write(data),
+    end: () => process.exit(0),
+    command: () => {}
+  };
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  rl.setPrompt('> ');
+
+  const look = state.CommandManager.get('look');
+  if (look) {
+    await look.execute('', player);
+  }
+  rl.prompt();
+
+  rl.on('line', async line => {
+    const input = line.trim();
+    if (input === 'quit') {
+      console.log('Goodbye.');
+      rl.close();
+      return;
+    }
+    const [commandName, ...argsArr] = input.split(' ');
+    const command = state.CommandManager.get(commandName) || state.CommandManager.find(commandName);
+    if (!command) {
+      console.log('Unknown command.');
+    } else {
+      await command.execute(argsArr.join(' '), player);
+    }
+    rl.prompt();
+  });
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add AGENTS guidelines for TypeScript-based single player engine
- introduce TypeScript config and npm start script
- create initialization and CLI loop that bypasses the telnet server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689501aa33bc832fa9c2ba9d3aae55b0